### PR TITLE
Add enum MAV_LANDED_STATE_GO_AROUND

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2969,6 +2969,9 @@
       <entry value="4" name="MAV_LANDED_STATE_LANDING">
         <description>MAV currently landing</description>
       </entry>
+      <entry value="5" name="MAV_LANDED_STATE_GO_AROUND">
+        <description>MAV currently aborting a landing</description>
+      </entry>
     </enum>
     <enum name="ADSB_ALTITUDE_TYPE">
       <description>Enumeration of the ADSB altimeter types</description>


### PR DESCRIPTION
Add enum MAV_LANDED_STATE_GO_AROUND so we know when it's happening. The aircraft will be in this state while:
- current NAV waypoint is NAV_LAND and flight_stage==ABORT_LANDING
- previous NAV waypoint is NAV_LAND and current NAV waypoint is NAV_CONTINUE_AND_CHANGE_ALT
- previous NAV waypoint is NAV_LAND and previous DO command is DO_GO_AROUND
